### PR TITLE
Correct link for navigating to Bangle.js app loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -39,8 +39,8 @@ function filterAppsForDevice(deviceId) {
     originalAppJSON = appJSON;
   if (deviceId=="BANGLEJS" || deviceId=="BANGLEJS2") {
     showToast(`Looks like you've got a <a href="https://www.espruino.com/Bangle.js" target="_blank">Bangle.js</a>.
-This Espruino App loader will make your Bangle run <b>just a single app</b>. For multiple apps specifically for
-Bangle.js, please see the <a href="https://www.banglejs.com/apps">Bangle.js App Loader</a>`, "warning", 20000);
+This Espruino App loader will make your Bangle run <b>only a single app</b>. For multiple apps that are specifically for
+Bangle.js, please see the <a href="https://banglejs.com/apps">Bangle.js App Loader</a>`, "warning", 20000);
   }
 
   var device = DEVICEINFO.find(d=>d.id==deviceId);


### PR DESCRIPTION
Updated warning message to clarify that the loader runs only a single app and corrected the link format so security errors do not pop up on chrome